### PR TITLE
update_kernel.sh: fix syntax error

### DIFF
--- a/update_kernel.sh
+++ b/update_kernel.sh
@@ -12,7 +12,7 @@ UPDATE=0
 KERNEL=
 PATCHVER=
 
-while [ $# > 0 ]; do
+while [ $# -gt 0 ]; do
 	case $1 in
 		-b|--build)
 			BUILD=1


### PR DESCRIPTION
Replace while [ $# > 0 ]; with while [ $# -gt 0 ]

The former redirects $# to a file '0' creating a stray file as the least
worrying of side effects.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>